### PR TITLE
Support exec2 and exec3This treats exec2/3 as expression blocks

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -136,6 +136,8 @@ const testCases = [
   ["Logical or (first value false)", "g = 0 || 2;", 2],
   ["Logical and shortcircuts", "0 && g = 10;", 0],
   ["Logical or shortcircuts", "1 || g = 10;", 0],
+  ["Exec2", "g = exec2(x = 5, x * 3);", 15],
+  ["Exec3", "g = exec3(x = 5, x = x * 3, x + 1);", 16],
 ];
 
 describe("Small test cases", () => {

--- a/tools/buildParser.js
+++ b/tools/buildParser.js
@@ -14,9 +14,6 @@ const grammar = {
       ["[0-9]+", "return 'DIGITS_TOKEN'"],
       ["[+\\-*/%]?=", "return 'ASSIGNMENT_OPERATOR_TOKEN'"],
       ["(\\&\\&)|\\|\\|", "return 'LOGICAL_OPERATOR_TOKEN'"],
-      ["if", "return 'IF'"],
-      ["exec2", "return 'EXEC_TWO'"],
-      ["exec3", "return 'EXEC_THREE'"],
       // https://github.com/justinfrankel/WDL/blob/63943fbac273b847b733aceecdb16703679967b9/WDL/eel2/eel2.l#L93
       ["[a-zA-Z_][a-zA-Z0-9._]*", "return 'IDENTIFIER_TOKEN'"],
       ["$", "return 'EOF'"],
@@ -88,23 +85,11 @@ const grammar = {
         "IDENTIFIER ( arguments )",
         "$$ = {type: 'CALL_EXPRESSION', callee: $1, arguments: $3, column: @1.first_column, line: @1.first_line}",
       ],
-      [
-        "EXEC_TWO ( expression , expression )",
-        "$$ = {type: 'EXPRESSION_BLOCK', body: [$3, $5], syntax: 'function', column: @1.first_column, line: @1.first_line}",
-      ],
-      [
-        "EXEC_THREE ( expression , expression , expression )",
-        "$$ = {type: 'EXPRESSION_BLOCK', body: [$3, $5, $7], syntax: 'function', column: @1.first_column, line: @1.first_line}",
-      ],
-      [
-        "IF ( argument , argument , argument )",
-        "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $3, consiquent: $5, alternate: $7, syntax: 'function', column: @1.first_column, line: @1.first_line}",
-      ],
     ],
     CONDITIONAL_EXPRESSION: [
       [
         "expression ? expression : expression",
-        "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $1, consiquent: $3, alternate: $5, syntax: 'ternary', column: @1.first_column, line: @1.first_line}",
+        "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $1, consiquent: $3, alternate: $5, column: @1.first_column, line: @1.first_line}",
       ],
     ],
     LOGICAL_EXPRESSION: [

--- a/tools/buildParser.js
+++ b/tools/buildParser.js
@@ -15,6 +15,8 @@ const grammar = {
       ["[+\\-*/%]?=", "return 'ASSIGNMENT_OPERATOR_TOKEN'"],
       ["(\\&\\&)|\\|\\|", "return 'LOGICAL_OPERATOR_TOKEN'"],
       ["if", "return 'IF'"],
+      ["exec2", "return 'EXEC_TWO'"],
+      ["exec3", "return 'EXEC_THREE'"],
       // https://github.com/justinfrankel/WDL/blob/63943fbac273b847b733aceecdb16703679967b9/WDL/eel2/eel2.l#L93
       ["[a-zA-Z_][a-zA-Z0-9._]*", "return 'IDENTIFIER_TOKEN'"],
       ["$", "return 'EOF'"],
@@ -86,15 +88,23 @@ const grammar = {
         "IDENTIFIER ( arguments )",
         "$$ = {type: 'CALL_EXPRESSION', callee: $1, arguments: $3, column: @1.first_column, line: @1.first_line}",
       ],
+      [
+        "EXEC_TWO ( expression , expression )",
+        "$$ = {type: 'EXPRESSION_BLOCK', body: [$3, $5], syntax: 'function', column: @1.first_column, line: @1.first_line}",
+      ],
+      [
+        "EXEC_THREE ( expression , expression , expression )",
+        "$$ = {type: 'EXPRESSION_BLOCK', body: [$3, $5, $7], syntax: 'function', column: @1.first_column, line: @1.first_line}",
+      ],
+      [
+        "IF ( argument , argument , argument )",
+        "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $3, consiquent: $5, alternate: $7, syntax: 'function', column: @1.first_column, line: @1.first_line}",
+      ],
     ],
     CONDITIONAL_EXPRESSION: [
       [
         "expression ? expression : expression",
         "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $1, consiquent: $3, alternate: $5, syntax: 'ternary', column: @1.first_column, line: @1.first_line}",
-      ],
-      [
-        "IF ( argument , argument , argument )",
-        "$$ = {type: 'CONDITIONAL_EXPRESSION', test: $3, consiquent: $5, alternate: $7, syntax: 'function', column: @1.first_column, line: @1.first_line}",
       ],
     ],
     LOGICAL_EXPRESSION: [

--- a/tools/prettyPrinter.js
+++ b/tools/prettyPrinter.js
@@ -4,7 +4,11 @@ function print(ast) {
       return ast.body.map(print).join("\n");
     }
     case "EXPRESSION_BLOCK": {
-      return ast.body.map(print).join("\n");
+      const expressions = ast.body.map(print);
+      if (ast.syntax === "function") {
+        return `exec${ast.body.length}(${expressions.join(", ")})`;
+      }
+      return expressions.join("\n");
     }
     case "BINARY_EXPRESSION": {
       return `${print(ast.left)} ${ast.operator} ${print(ast.right)}`;

--- a/tools/prettyPrinter.js
+++ b/tools/prettyPrinter.js
@@ -5,9 +5,6 @@ function print(ast) {
     }
     case "EXPRESSION_BLOCK": {
       const expressions = ast.body.map(print);
-      if (ast.syntax === "function") {
-        return `exec${ast.body.length}(${expressions.join(", ")})`;
-      }
       return expressions.join("\n");
     }
     case "BINARY_EXPRESSION": {
@@ -24,9 +21,6 @@ function print(ast) {
       const test = print(ast.test);
       const consiquent = print(ast.consiquent);
       const alternate = print(ast.alternate);
-      if (ast.syntax === "function") {
-        return `if(${test}, ${consiquent}, ${alternate})`;
-      }
       return `${test} ? ${consiquent} : ${alternate}`;
     }
     case "UNARY_EXPRESSION": {

--- a/tools/prettyPrinter.test.js
+++ b/tools/prettyPrinter.test.js
@@ -6,7 +6,7 @@ function transform(code) {
 }
 
 function joinLines(str) {
-  return str.replace("\n", " ")
+  return str.replace("\n", " ");
 }
 
 const expressions = [
@@ -17,6 +17,9 @@ const expressions = [
   "x = if(1, a = 10; y = 11;, 2);",
   "x = 1 ? 2 : 3;",
   "x = -1;",
+  "x = if(5, 6, 7);",
+  "x = exec2(5, 6);",
+  "x = exec3(5, 6, 7);",
 ];
 expressions.forEach(expression => {
   test(`"${expression}" can be pretty printed`, () => {


### PR DESCRIPTION
Each expression is evaluated and the last return value is returned.

This continues the precedence I set with `if()`. Rather than having
a special AST node for these magic functions, I'll use the semantically
correct node (in this case `EXPRESSION_BLOCK`) with a special
`syntax`property to clarify which syntax it used.

This should allow the parser to preserve the syntax used -- which is
important for our pretty printer -- without having this weird syntax
leaking into the emitter/optimizer portions of our code base. This also
reminded me that I should group the `if(a,b,c)` parser as a subtype of
`FUNCTION_CALL` (its syntax) rather than`CONDITIONAL_EXPRESSION` (its
meaning).