### PR TITLE
Add some initial epsilon checks

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -64,25 +64,6 @@ function compileModule({
   // TODO: We could pass in the arity here to get a compile-time check that we
   // passed the right number of arguments.
   function resolveLocalFunc(name) {
-    // Inline functions
-    switch (name) {
-      case "abs":
-        return [op.f64_abs];
-      case "sqrt":
-        return [op.f64_sqrt];
-      case "int":
-        return [op.f64_floor];
-      case "min":
-        return [op.f64_min];
-      case "max":
-        return [op.f64_max];
-      case "above":
-        return [op.f64_lt, op.f64_convert_i32_s];
-      case "below":
-        return [op.f64_gt, op.f64_convert_i32_s];
-      case "equal":
-        return [op.f64_eq, op.f64_convert_i32_s];
-    }
     const offset = localFuncResolver.get(name);
     return [op.call, ...unsignedLEB128(offset)];
   }

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -6,13 +6,14 @@ const {
   BLOCK,
 } = require("./encoding");
 
+const EPSILON = 0.00001;
 // Takes an f64 on the stack and leaves an int32 boolean representing if it's
 // within epsilon of zero.
-const IS_ZEROISH = [op.f64_abs, op.f64_const, ...encodef64(0.0001), op.f64_lt];
+const IS_ZEROISH = [op.f64_abs, op.f64_const, ...encodef64(EPSILON), op.f64_lt];
 const IS_NOT_ZEROISH = [
   op.f64_abs,
   op.f64_const,
-  ...encodef64(0.0001),
+  ...encodef64(EPSILON),
   op.f64_gt,
 ];
 

--- a/src/test.js
+++ b/src/test.js
@@ -55,6 +55,7 @@ const testCases = [
   ["Number", "g = 5;", 5],
   ["Number with decimal", "g = 5.5;", 5.5],
   ["Number with decimal and no leading whole", "g = .5;", 0.5],
+  ["Number with decimal and no trailing dec", "g = 5.;", 5],
   ["Optional final semi", "g = 5; g = 10", 10],
   ["Unary negeation", "g = -10;", -10],
   ["Unary plus", "g = +10;", 10],

--- a/src/test.js
+++ b/src/test.js
@@ -166,6 +166,8 @@ const testCases = [
   ["Case insensitive vars", "G = 10;", 10],
   ["Case insensitive funcs", "g = InT(10);", 10],
   ["Consecutive semis", "g = 10;;; ;g = 20;;", 20],
+  ["Equality (< epsilon)", "g = 0.00009 == 0;", 1],
+  ["Equality (< -epsilon)", "g = -0.00009 == 0;", 1],
 ];
 
 describe("Small test cases", () => {

--- a/src/test.js
+++ b/src/test.js
@@ -166,8 +166,8 @@ const testCases = [
   ["Case insensitive vars", "G = 10;", 10],
   ["Case insensitive funcs", "g = InT(10);", 10],
   ["Consecutive semis", "g = 10;;; ;g = 20;;", 20],
-  ["Equality (< epsilon)", "g = 0.00009 == 0;", 1],
-  ["Equality (< -epsilon)", "g = -0.00009 == 0;", 1],
+  ["Equality (< epsilon)", "g = 0.000009 == 0;", 1],
+  ["Equality (< -epsilon)", "g = -0.000009 == 0;", 1],
 ];
 
 describe("Small test cases", () => {

--- a/tools/parseMilk.js
+++ b/tools/parseMilk.js
@@ -43,7 +43,26 @@ function getEels(milk) {
   return eels;
 }
 
+const BAD = new Set([
+  "fixtures/mega/!Dawid.milk",
+  "fixtures/mega/092j09jf09j09je09j9j09j09jef09j09je0f9j.milk",
+  // Ends with a comment: x = // something
+  "fixtures/mega/123456.milk",
+  "fixtures/mega/123456remix1.milk",
+  "fixtures/mega/123456remix2.milk",
+  "fixtures/mega/123456remix3bom.milk",
+  "fixtures/mega/123456remix3bomseila.milk",
+  // Newline instead of semi
+  "fixtures/mega/160.milk",
+  "fixtures/mega/161.milk",
+  "fixtures/mega/2009 4th of July with AdamFX n Martin - into the fireworks B.milk",
+  "fixtures/mega/2009 4th of July with AdamFX n Martin - into the fireworks E.milk",
+]);
+
 function validate(milkPath, context) {
+  if (BAD.has(milkPath)) {
+    return;
+  }
   const presetIni = fs.readFileSync(milkPath, { encoding: "utf8" });
   const eels = getEels(presetIni);
 


### PR DESCRIPTION
Makes progress toward: https://github.com/captbaritone/eel-wasm/issues/8

- [x] `&&`
- [x] `||`
- [ ] `bor()`
- [ ] `band()` (Do we even have this?)
- [ ] `sigmoid`
- [x] `if()`
- [ ] `not()` or `!`
- [x] `==` and `equal`
- [ ] `!=`
- [ ] `_mem` (I'm not sure what this is)
- [ ] `_gmem` (I'm not sure what this is)
- [x] `while()`