### PR TITLE
Allow compiling to different Eel versions (v1/v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ const functions = {
   setXToY: { pool: 'poolA', code: "x = y;" }
 };
 
+
+// Eel v1 and Eel v2 only have one difference. Eel v1, `rand(n)` floors its return value, and Eel v2 leaves the decimal content.
+const eelVersion = 2; // 1 or 2
+
 // Build (compile/initialize) the Wasm module
-const mod = await loadModule({ pools, functions });
+const mod = await loadModule({ pools, functions, eelVersion });
 
 console.log(`x starts at 0. x:${globals.x.value}`);
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eel-wasm",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "dist/src/index.js",
   "license": "MIT",
   "homepage": "https://github.com/captbaritone/eel-wasm",

--- a/packages/compiler/src/loader.ts
+++ b/packages/compiler/src/loader.ts
@@ -1,5 +1,6 @@
 import shims from "./shims";
 import { compileModule } from "./compiler";
+import { EelVersion } from "./types";
 
 type LoadModuleOptions = {
   pools: {
@@ -13,9 +14,14 @@ type LoadModuleOptions = {
       code: string;
     };
   };
+  eelVersion?: EelVersion;
 };
 
-export async function loadModule({ pools, functions }: LoadModuleOptions) {
+export async function loadModule({
+  pools,
+  functions,
+  eelVersion = 2,
+}: LoadModuleOptions) {
   let compilerPools: { [name: string]: Set<string> } = {};
   Object.entries(pools).forEach(([key, globals]) => {
     compilerPools[key] = new Set(Object.keys(globals));
@@ -23,6 +29,7 @@ export async function loadModule({ pools, functions }: LoadModuleOptions) {
   const buffer = compileModule({
     pools: compilerPools,
     functions,
+    eelVersion,
   });
   const mod = await WebAssembly.compile(buffer);
 

--- a/packages/compiler/src/shims.ts
+++ b/packages/compiler/src/shims.ts
@@ -11,7 +11,7 @@ const shims: Shims = {
   acos: Math.acos,
   atan: Math.atan,
   atan2: Math.atan2,
-  rand: a => Math.floor(Math.random() * a),
+  rand: a => Math.random() * a,
   pow: Math.pow,
   log: Math.log,
   log10: Math.log10,

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -124,6 +124,8 @@ export interface FunctionDefinition extends TypedFunction {
   localVariables?: number[];
 }
 
+export type EelVersion = 1 | 2;
+
 export interface CompilerContext {
   resolveVar(name: string): number;
   resolveFunc(name: string): number[] | null;

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -39,9 +39,10 @@ const EDITOR_OPTIONS = {
 function App() {
   const { globals, addGlobal, removeGlobal } = useGlobals();
   const [eel, setEel] = useUrlState("eel", "foo = 1;");
+  const [eelVersion, setEelVersion] = useUrlState("eelVersion", "2");
   const [astString, setAstString] = useState(null);
   const [ast, astError] = useAst(eel);
-  const [wasm, wasmError] = useWasm(eel, globals);
+  const [wasm, wasmError] = useWasm(eel, globals, Number(eelVersion));
   const [wat] = useWat(wasm);
   const anyErrors = astError != null || wasmError != null;
   const [mod, modError] = useMod(anyErrors ? null : wasm, globals);
@@ -122,6 +123,17 @@ function App() {
           onChange={(ev, value) => setEel(value)}
           options={{ ...EDITOR_OPTIONS, lineNumbers: "on" }}
         />
+        <div>
+          Eel Version:{" "}
+          <select
+            style={{ display: "inline" }}
+            onChange={e => setEelVersion(e.target.value)}
+            value={eelVersion}
+          >
+            <option value="1">V1</option>
+            <option value="2">V2</option>
+          </select>
+        </div>
         <button onClick={run} disabled={run == null}>
           Run
         </button>

--- a/packages/playground/src/hooks.js
+++ b/packages/playground/src/hooks.js
@@ -66,7 +66,7 @@ export function useAst(eel) {
   return [ast, astError];
 }
 
-export function useWasm(code, globals) {
+export function useWasm(code, globals, eelVersion) {
   const [wasm, setWasm] = useState(null);
   const [wasmError, setWasmError] = useState(null);
 
@@ -79,16 +79,17 @@ export function useWasm(code, globals) {
         functions: {
           main: { pool: "main", code }
         },
-        pools: { main: new Set(Object.keys(globals)) }
+        pools: { main: new Set(Object.keys(globals)) },
+        eelVersion
       });
       setWasm(wasm);
       setWasmError(null);
     } catch (e) {
       setWasmError(e);
     }
-  }, [code, globals]);
+  }, [code, eelVersion, globals]);
 
-  return [wasm, wasmError];
+  return [wasm, wasmError, eelVersion];
 }
 
 export function useWat(wasm) {


### PR DESCRIPTION
Fixes #38

Note that if you are using your own shims object (rather than the one exported by this library) you will need to update the `rand` function.