### PR TITLE
Restrict shared reg variable regex to match whole variable name

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -108,7 +108,7 @@ export function compileModule({
     const context: CompilerContext = {
       resolveVar: name => {
         // The `reg00`-`reg99` variables are special in that they are shared between all pools.
-        if (/reg\d\d/.test(name)) {
+        if (/^reg\d\d$/.test(name)) {
           return varResolver.get(null, name);
         }
         return varResolver.get(pool, name);


### PR DESCRIPTION
We can be more restrictive on what we consider a shared reg var, since they are always defined as `reg00-reg99`

I doubt we were matching variables we shouldn't (although who knows with 10s of thousands of presets), but maybe a tiny speed boost from a more specific regex?