### PR TITLE
Don't create module methods for empty equations

### DIFF
--- a/packages/compiler/src/__tests__/integration.test.js
+++ b/packages/compiler/src/__tests__/integration.test.js
@@ -82,6 +82,24 @@ describe("Small test cases", () => {
   });
 });
 
+// This
+test("Empty equations are not created", async () => {
+  const mod = await loadModule({
+    pools: { main: {} },
+    functions: {
+      empty: { pool: "main", code: "" },
+      whiteSpace: { pool: "main", code: "  \n\t " },
+      comment: { pool: "main", code: "// IGNORE THIS" },
+      hasCode: { pool: "main", code: "1" },
+    },
+  });
+
+  expect(mod.exports.empty).toBe(undefined);
+  expect(mod.exports.whiteSpace).toBe(undefined);
+  expect(mod.exports.comment).toBe(undefined);
+  expect(mod.exports.hasCode).not.toBe(undefined);
+});
+
 describe("Scopes", () => {
   test("isolate variables", async () => {
     const ax = new WebAssembly.Global({ value: "f64", mutable: true }, 0);

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -104,6 +104,12 @@ export function compileModule({
         "Got passed unparsed code without setting the preParsed flag"
       );
     }
+    if (ast.type !== "SCRIPT") {
+      throw new Error("Invalid AST");
+    }
+    if (ast.body.length === 0) {
+      return;
+    }
     const localVariables: number[] = [];
     const context: CompilerContext = {
       resolveVar: name => {

--- a/packages/compiler/tools/testCases.ts
+++ b/packages/compiler/tools/testCases.ts
@@ -1,5 +1,4 @@
 const testCases: [string, string, number][] = [
-  ["Empty program", "", 0],
   ["Expressions", "g = ((6- -7)+ 3);", 16],
   ["Number", "g = 5;", 5],
   ["Number with decimal", "g = 5.5;", 5.5],


### PR DESCRIPTION
This will allow consumers to know when it's safe to skip running
equations and any additional setup/cleanup work that's needed when that
equation can cause side effects.