### PR TITLE
A much more efficient IEEE-754 writer

### DIFF
--- a/packages/compiler/src/ieee754.ts
+++ b/packages/compiler/src/ieee754.ts
@@ -1,66 +1,14 @@
-// Copied from https://github.com/feross/ieee754/blob/master/index.js
+
 export function write(buffer: Uint8Array, value: number) {
-  // Originally these four were arguments, but we only ever use it like this.
-  const offset = 0;
-  const isLE = true;
-  let mLen = 52;
-  const nBytes = 8;
+  const base =
+    new ArrayBuffer(8)
+  const view =
+    new DataView(base)
 
-  var e, m, c;
-  var eLen = nBytes * 8 - mLen - 1;
-  var eMax = (1 << eLen) - 1;
-  var eBias = eMax >> 1;
-  var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
-  var i = isLE ? 0 : nBytes - 1;
-  var d = isLE ? 1 : -1;
-  var s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0;
+  view.setFloat64(0, value)
 
-  value = Math.abs(value);
+  const result =
+    (new Uint8Array(base)).reverse()
 
-  if (isNaN(value) || value === Infinity) {
-    m = isNaN(value) ? 1 : 0;
-    e = eMax;
-  } else {
-    e = Math.floor(Math.log(value) / Math.LN2);
-    if (value * (c = Math.pow(2, -e)) < 1) {
-      e--;
-      c *= 2;
-    }
-    if (e + eBias >= 1) {
-      value += rt / c;
-    } else {
-      value += rt * Math.pow(2, 1 - eBias);
-    }
-    if (value * c >= 2) {
-      e++;
-      c /= 2;
-    }
-
-    if (e + eBias >= eMax) {
-      m = 0;
-      e = eMax;
-    } else if (e + eBias >= 1) {
-      m = (value * c - 1) * Math.pow(2, mLen);
-      e = e + eBias;
-    } else {
-      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
-      e = 0;
-    }
-  }
-
-  for (
-    ;
-    mLen >= 8;
-    buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8
-  ) {}
-
-  e = (e << mLen) | m;
-  eLen += mLen;
-  for (
-    ;
-    eLen > 0;
-    buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8
-  ) {}
-
-  buffer[offset + i - d] |= s * 128;
+  buffer.set(result, 0)
 }


### PR DESCRIPTION
Hey @captbaritone how you doing? So as you already know, I'm making a tiny assembler for webassembly and doing so I found out that the JS provides a native system to make IEEE-754. I played a lot with the wabt's outputs and wrote many tests on my end to make sure this way is right and after replacing it with the one you had, running the tests didn't show any problem. So hope it works fine and you enjoy it. The formula that I found to the native f64 encoder also is this:

<img width="787" alt="The native way to make IEEE-754" src="https://user-images.githubusercontent.com/2157285/134722266-9f3376f8-ff55-43f5-a6ad-92667ac38f9c.png">