### PR TITLE
Fix Netlify deploy by specifying Node.js 20

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,5 @@ publish = "packages/playground/build"
 command = "pnpm build"
 
 [build.environment]
+NODE_VERSION = "20"
 NODE_OPTIONS = "--max_old_space_size=4096"


### PR DESCRIPTION
Fixes the Netlify deployment failure caused by the default Node.js version (v10.24.1) being too old for pnpm.

This PR adds `NODE_VERSION=20` to the Netlify build environment configuration, ensuring a compatible Node.js version is used during the build process.